### PR TITLE
TBE Header Parsing in C

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+# Ignore executable files
+*.exe
+
+# Ignore macOS system files
+.DS_Store
+
+# Ignore Python bytecode and cache
+*.pyc
+__pycache__/
+
+# Ignore VS files
+.vs

--- a/c_tbe/c_conv/include/tbe_header_parser.h
+++ b/c_tbe/c_conv/include/tbe_header_parser.h
@@ -1,0 +1,36 @@
+#ifndef TBE_HEADER_H
+#define TBE_HEADER_H
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+// Define constants for maximum lengths
+#define MAX_NAME_LEN 256
+#define MAX_VALUE_LEN 1024
+
+// Structure to hold an attribute (ATT)
+typedef struct Attribute {
+    char name[MAX_NAME_LEN];
+    char value[MAX_VALUE_LEN];
+    struct Attribute* next; // Pointer to the next attribute in the linked list
+} Attribute;
+
+// Structure to hold a TBL section
+typedef struct TBLSection {
+    char name[MAX_NAME_LEN];       // Name of the TBL section
+    Attribute* attributes;         // Linked list of attributes for this section
+    struct TBLSection* next;       // Pointer to the next TBL section
+} TBLSection;
+
+// Structure to represent the entire TBE header
+typedef struct TBEHeader {
+    TBLSection* sections;          // Linked list of TBL sections
+} TBEHeader;
+
+// Function prototypes
+TBEHeader* parse_tbe_header(const char* filename);
+void free_tbe_header(TBEHeader* header);
+void print_tbe_header(const TBEHeader* header);
+
+#endif // TBE_HEADER_H

--- a/c_tbe/c_conv/src/main.c
+++ b/c_tbe/c_conv/src/main.c
@@ -1,0 +1,16 @@
+#include "../include/tbe_header_parser.h"
+
+int main() {
+    const char* filename = "sample_data/saq_bluesky_bgd_20211001_20230430_inv_tbe.csv";
+    TBEHeader* header = parse_tbe_header(filename);
+
+    if (header) {
+        print_tbe_header(header);
+        free_tbe_header(header);
+    }
+    else {
+        fprintf(stderr, "Failed to parse TBE header.\n");
+    }
+
+    return 0;
+}

--- a/c_tbe/c_conv/src/tbe_header_parser.c
+++ b/c_tbe/c_conv/src/tbe_header_parser.c
@@ -1,0 +1,133 @@
+#include "../include/tbe_header_parser.h"
+
+TBEHeader* parse_tbe_header(const char* filename) {
+    FILE* file = fopen(filename, "r");
+    if (!file) {
+        perror("Error opening TBE file");
+        return NULL;
+    }
+
+    TBEHeader* header = malloc(sizeof(TBEHeader));
+    if (!header) {
+        perror("Memory allocation failed");
+        fclose(file);
+        return NULL;
+    }
+    header->sections = NULL;
+    TBLSection* current_section = NULL;
+
+    char line[2048]; // Buffer for reading lines
+    while (fgets(line, sizeof(line), file)) {
+        line[strcspn(line, "\r\n")] = '\0'; // Remove newline characters
+        if (strlen(line) == 0) continue;   // Skip empty lines
+
+        char* tokens[50];
+        int token_count = 0;
+        char* token = strtok(line, ",");
+        while (token && token_count < 50) {
+            tokens[token_count++] = token;
+            token = strtok(NULL, ",");
+        }
+
+        if (token_count == 0) {
+            fprintf(stderr, "Warning: Empty or invalid line encountered.\n");
+            continue;
+        }
+
+        if (strncmp(tokens[0], "TBL", 3) == 0) {
+            if (token_count < 1) {
+                fprintf(stderr, "Warning: TBL section missing name.\n");
+                continue;
+            }
+
+            TBLSection* new_section = malloc(sizeof(TBLSection));
+            if (!new_section) {
+                perror("Memory allocation failed");
+                fclose(file);
+                return NULL;
+            }
+            strncpy(new_section->name, tokens[0] + 4, MAX_NAME_LEN); // Remove 'TBL ' prefix
+            new_section->attributes = NULL;
+            new_section->next = NULL;
+
+            if (!header->sections) {
+                header->sections = new_section;
+            }
+            else {
+                TBLSection* last_section = header->sections;
+                while (last_section->next) last_section = last_section->next;
+                last_section->next = new_section;
+            }
+            current_section = new_section;
+
+        }
+        else if (strncmp(tokens[0], "ATT", 3) == 0) {
+            if (!current_section) {
+                fprintf(stderr, "Warning: ATT line encountered without an active TBL section.\n");
+                continue;
+            }
+
+            for (int i = 1; i < token_count; i++) {
+                if (strlen(tokens[i]) == 0) {
+                    fprintf(stderr, "Warning: Empty attribute name in ATT line.\n");
+                    continue;
+                }
+
+                Attribute* new_attr = malloc(sizeof(Attribute));
+                if (!new_attr) {
+                    perror("Memory allocation failed");
+                    fclose(file);
+                    return NULL;
+                }
+                strncpy(new_attr->name, tokens[i], MAX_NAME_LEN);
+                new_attr->value[0] = '\0'; // Initialize value to empty
+                new_attr->next = NULL;
+
+                if (!current_section->attributes) {
+                    current_section->attributes = new_attr;
+                }
+                else {
+                    Attribute* last_attr = current_section->attributes;
+                    while (last_attr->next) last_attr = last_attr->next;
+                    last_attr->next = new_attr;
+                }
+            }
+        }
+        else {
+            fprintf(stderr, "Warning: Unknown line type '%s' encountered. Skipping.\n", tokens[0]);
+        }
+    }
+
+    fclose(file);
+    return header;
+}
+
+void free_tbe_header(TBEHeader* header) {
+    TBLSection* section = header->sections;
+    while (section) {
+        Attribute* attr = section->attributes;
+        while (attr) {
+            Attribute* next_attr = attr->next;
+            free(attr);
+            attr = next_attr;
+        }
+        TBLSection* next_section = section->next;
+        free(section);
+        section = next_section;
+    }
+    free(header);
+}
+
+void print_tbe_header(const TBEHeader* header) {
+    const TBLSection* section = header->sections;
+    while (section) {
+        printf("TBL Section: %s\n", section->name);
+        const Attribute* attr = section->attributes;
+        while (attr) {
+            printf("  Attribute: %s = %s\n", attr->name, attr->value);
+            attr = attr->next;
+        }
+        section = section->next;
+        printf("\n");
+    }
+}


### PR DESCRIPTION
### NOTE: Closed because my new pull request, https://github.com/oss-slu/tbe/pull/87, fixes this issue.

## **Summary**
Fixes Issue #48. This PR adds a C program to parse TBE file headers, extract metadata, and store it in structured C-native data types.

## **Key Features**
- Parses `TBL` sections and associated `ATT` attributes.
- Stores metadata in hierarchical structs for easy access.
- Prints parsed metadata for verification.
- Handles errors and ensures proper memory management.
- Adds a `.gitignore` file to exclude various files.
- Ensures compatibility with the current file structure.

## **Testing**
1. Built the program with:
```
gcc -I./c_tbe/c_conv/include -o tbe_parser ./c_tbe/c_conv/src/main.c ./c_tbe/c_conv/src/tbe_header_parser.c
```
3. Ran with a sample file:
```
./tbe_parser
```