### PR TITLE
Add TBE Header Writer and Enhance TBE Header Parser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+# Ignore executable files
+*.exe
+
+# Ignore macOS system files
+.DS_Store
+
+# Ignore Python bytecode and cache
+*.pyc
+__pycache__/
+
+# Ignore VS files
+.vs

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ __pycache__/
 
 # Ignore VS files
 .vs
+
+# Ignore generated CSV files
+c_tbe/output_data/*

--- a/c_tbe/c_conv/include/tbe_header_parser.h
+++ b/c_tbe/c_conv/include/tbe_header_parser.h
@@ -1,31 +1,33 @@
-#ifndef TBE_HEADER_H
-#define TBE_HEADER_H
+#ifndef TBE_HEADER_PARSER_H
+#define TBE_HEADER_PARSER_H
 
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
-// Define constants for maximum lengths
+// Define maximum lengths for names and values
 #define MAX_NAME_LEN 256
-#define MAX_VALUE_LEN 1024
+#define MAX_VALUE_LEN 512
 
-// Structure to hold an attribute (ATT)
+// Structure for a key-value pair (used for global metadata)
 typedef struct Attribute {
     char name[MAX_NAME_LEN];
     char value[MAX_VALUE_LEN];
-    struct Attribute* next; // Pointer to the next attribute in the linked list
+    struct Attribute* next;
 } Attribute;
 
-// Structure to hold a TBL section
+// Structure for a TBL section
 typedef struct TBLSection {
-    char name[MAX_NAME_LEN];       // Name of the TBL section
-    Attribute* attributes;         // Linked list of attributes for this section
-    struct TBLSection* next;       // Pointer to the next TBL section
+    char name[MAX_NAME_LEN];
+    Attribute* attributes;
+    struct TBLSection* next;
 } TBLSection;
 
-// Structure to represent the entire TBE header
+// Structure for the entire TBE header
 typedef struct TBEHeader {
-    TBLSection* sections;          // Linked list of TBL sections
+    Attribute* bgn_attributes;    // Global metadata before TBL sections
+    Attribute* eot_attributes;    // Global metadata after TBL sections
+    TBLSection* sections;         // Linked list of TBL sections
 } TBEHeader;
 
 // Function prototypes
@@ -33,4 +35,4 @@ TBEHeader* parse_tbe_header(const char* filename);
 void free_tbe_header(TBEHeader* header);
 void print_tbe_header(const TBEHeader* header);
 
-#endif // TBE_HEADER_H
+#endif // TBE_HEADER_PARSER_H

--- a/c_tbe/c_conv/include/tbe_header_parser.h
+++ b/c_tbe/c_conv/include/tbe_header_parser.h
@@ -1,0 +1,36 @@
+#ifndef TBE_HEADER_H
+#define TBE_HEADER_H
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+// Define constants for maximum lengths
+#define MAX_NAME_LEN 256
+#define MAX_VALUE_LEN 1024
+
+// Structure to hold an attribute (ATT)
+typedef struct Attribute {
+    char name[MAX_NAME_LEN];
+    char value[MAX_VALUE_LEN];
+    struct Attribute* next; // Pointer to the next attribute in the linked list
+} Attribute;
+
+// Structure to hold a TBL section
+typedef struct TBLSection {
+    char name[MAX_NAME_LEN];       // Name of the TBL section
+    Attribute* attributes;         // Linked list of attributes for this section
+    struct TBLSection* next;       // Pointer to the next TBL section
+} TBLSection;
+
+// Structure to represent the entire TBE header
+typedef struct TBEHeader {
+    TBLSection* sections;          // Linked list of TBL sections
+} TBEHeader;
+
+// Function prototypes
+TBEHeader* parse_tbe_header(const char* filename);
+void free_tbe_header(TBEHeader* header);
+void print_tbe_header(const TBEHeader* header);
+
+#endif // TBE_HEADER_H

--- a/c_tbe/c_conv/include/tbe_header_writer.h
+++ b/c_tbe/c_conv/include/tbe_header_writer.h
@@ -1,0 +1,9 @@
+#ifndef TBE_HEADER_WRITER_H
+#define TBE_HEADER_WRITER_H
+
+#include "tbe_header_parser.h"
+
+// Function prototype
+int export_tbe_header(const TBEHeader* header, const char* filename);
+
+#endif // TBE_HEADER_WRITER_H

--- a/c_tbe/c_conv/src/main.c
+++ b/c_tbe/c_conv/src/main.c
@@ -1,0 +1,16 @@
+#include "../include/tbe_header_parser.h"
+
+int main() {
+    const char* filename = "sample_data/saq_bluesky_bgd_20211001_20230430_inv_tbe.csv";
+    TBEHeader* header = parse_tbe_header(filename);
+
+    if (header) {
+        print_tbe_header(header);
+        free_tbe_header(header);
+    }
+    else {
+        fprintf(stderr, "Failed to parse TBE header.\n");
+    }
+
+    return 0;
+}

--- a/c_tbe/c_conv/src/main.c
+++ b/c_tbe/c_conv/src/main.c
@@ -1,11 +1,26 @@
 #include "../include/tbe_header_parser.h"
+#include "../include/tbe_header_writer.h"
 
 int main() {
-    const char* filename = "sample_data/saq_bluesky_bgd_20211001_20230430_inv_tbe.csv";
-    TBEHeader* header = parse_tbe_header(filename);
+    const char* input_filename = "sample_data/saq_bluesky_bgd_20211001_20230430_inv_tbe.csv";
+    const char* output_filename = "c_tbe/output_data/exported_tbe.csv";
+
+    // Parse the TBE header
+    TBEHeader* header = parse_tbe_header(input_filename);
 
     if (header) {
+        // Print the parsed header
         print_tbe_header(header);
+
+        // Export the header back to the TBE format
+        if (export_tbe_header(header, output_filename) == 0) {
+            printf("TBE header exported successfully to %s.\n", output_filename);
+        }
+        else {
+            fprintf(stderr, "Failed to export TBE header.\n");
+        }
+
+        // Free allocated memory
         free_tbe_header(header);
     }
     else {

--- a/c_tbe/c_conv/src/tbe_header_parser.c
+++ b/c_tbe/c_conv/src/tbe_header_parser.c
@@ -1,5 +1,28 @@
 #include "../include/tbe_header_parser.h"
 
+// Helper function to add an attribute to a linked list
+static void add_attribute(Attribute** head, const char* name, const char* value) {
+    Attribute* new_attr = malloc(sizeof(Attribute));
+    if (!new_attr) {
+        perror("Memory allocation failed for Attribute");
+        exit(EXIT_FAILURE);
+    }
+    strncpy(new_attr->name, name, MAX_NAME_LEN - 1);
+    new_attr->name[MAX_NAME_LEN - 1] = '\0';
+    strncpy(new_attr->value, value, MAX_VALUE_LEN - 1);
+    new_attr->value[MAX_VALUE_LEN - 1] = '\0';
+    new_attr->next = NULL;
+
+    if (!*head) {
+        *head = new_attr;
+    }
+    else {
+        Attribute* current = *head;
+        while (current->next) current = current->next;
+        current->next = new_attr;
+    }
+}
+
 TBEHeader* parse_tbe_header(const char* filename) {
     FILE* file = fopen(filename, "r");
     if (!file) {
@@ -9,18 +32,27 @@ TBEHeader* parse_tbe_header(const char* filename) {
 
     TBEHeader* header = malloc(sizeof(TBEHeader));
     if (!header) {
-        perror("Memory allocation failed");
+        perror("Memory allocation failed for TBEHeader");
         fclose(file);
         return NULL;
     }
+    header->bgn_attributes = NULL;
+    header->eot_attributes = NULL;
     header->sections = NULL;
     TBLSection* current_section = NULL;
 
     char line[2048]; // Buffer for reading lines
+    int line_number = 0;
+    int in_bgn_section = 0;
+    int in_eot_section = 0;
+
     while (fgets(line, sizeof(line), file)) {
-        line[strcspn(line, "\r\n")] = '\0'; // Remove newline characters
+        line_number++;
+        // Remove newline characters
+        line[strcspn(line, "\r\n")] = '\0';
         if (strlen(line) == 0) continue;   // Skip empty lines
 
+        // Tokenize the line
         char* tokens[50];
         int token_count = 0;
         char* token = strtok(line, ",");
@@ -30,72 +62,118 @@ TBEHeader* parse_tbe_header(const char* filename) {
         }
 
         if (token_count == 0) {
-            fprintf(stderr, "Warning: Empty or invalid line encountered.\n");
+            fprintf(stderr, "Warning [Line %d]: Empty or invalid line encountered.\n", line_number);
             continue;
         }
 
-        if (strncmp(tokens[0], "TBL", 3) == 0) {
-            if (token_count < 1) {
-                fprintf(stderr, "Warning: TBL section missing name.\n");
-                continue;
-            }
+        // Skip header line if present
+        if (line_number == 1 && strncmp(tokens[0], "TBL", 3) == 0) {
+            continue; // Assume first line is a header
+        }
 
-            TBLSection* new_section = malloc(sizeof(TBLSection));
-            if (!new_section) {
-                perror("Memory allocation failed");
-                fclose(file);
-                return NULL;
+        // Handle BGN section
+        if (strncmp(tokens[0], "BGN", 3) == 0) {
+            in_bgn_section = 1;
+            in_eot_section = 0;
+            if (token_count >= 3) {
+                add_attribute(&header->bgn_attributes, tokens[1], tokens[2]);
             }
-            strncpy(new_section->name, tokens[0] + 4, MAX_NAME_LEN); // Remove 'TBL ' prefix
-            new_section->attributes = NULL;
-            new_section->next = NULL;
-
-            if (!header->sections) {
-                header->sections = new_section;
+            else if (token_count == 2) {
+                add_attribute(&header->bgn_attributes, tokens[1], "");
             }
             else {
-                TBLSection* last_section = header->sections;
-                while (last_section->next) last_section = last_section->next;
-                last_section->next = new_section;
+                fprintf(stderr, "Warning [Line %d]: BGN line missing key or value.\n", line_number);
             }
-            current_section = new_section;
-
+            continue;
         }
-        else if (strncmp(tokens[0], "ATT", 3) == 0) {
-            if (!current_section) {
-                fprintf(stderr, "Warning: ATT line encountered without an active TBL section.\n");
-                continue;
+
+        // Handle EOT section
+        if (strncmp(tokens[0], "EOT", 3) == 0) {
+            in_eot_section = 1;
+            in_bgn_section = 0;
+            if (token_count >= 3) {
+                add_attribute(&header->eot_attributes, tokens[1], tokens[2]);
             }
+            else if (token_count == 2) {
+                add_attribute(&header->eot_attributes, tokens[1], "");
+            }
+            else {
+                fprintf(stderr, "Warning [Line %d]: EOT line missing key or value.\n", line_number);
+            }
+            continue;
+        }
 
-            for (int i = 1; i < token_count; i++) {
-                if (strlen(tokens[i]) == 0) {
-                    fprintf(stderr, "Warning: Empty attribute name in ATT line.\n");
-                    continue;
-                }
+        // Handle continuation lines for BGN and EOT
+        if (in_bgn_section || in_eot_section) {
+            if (token_count >= 3) {
+                Attribute** attr_list = in_bgn_section ? &header->bgn_attributes : &header->eot_attributes;
+                add_attribute(attr_list, tokens[1], tokens[2]);
+            }
+            else if (token_count == 2) {
+                Attribute** attr_list = in_bgn_section ? &header->bgn_attributes : &header->eot_attributes;
+                add_attribute(attr_list, tokens[1], "");
+            }
+            else {
+                fprintf(stderr, "Warning [Line %d]: Continuation line missing key or value.\n", line_number);
+            }
+            continue;
+        }
 
-                Attribute* new_attr = malloc(sizeof(Attribute));
-                if (!new_attr) {
-                    perror("Memory allocation failed");
+        // Handle TBL sections
+        if (strncmp(tokens[0], "TBL", 3) == 0) {
+            if (token_count >= 2) {
+                TBLSection* new_section = malloc(sizeof(TBLSection));
+                if (!new_section) {
+                    perror("Memory allocation failed for TBLSection");
                     fclose(file);
+                    free_tbe_header(header);
                     return NULL;
                 }
-                strncpy(new_attr->name, tokens[i], MAX_NAME_LEN);
-                new_attr->value[0] = '\0'; // Initialize value to empty
-                new_attr->next = NULL;
+                strncpy(new_section->name, tokens[1], MAX_NAME_LEN - 1);
+                new_section->name[MAX_NAME_LEN - 1] = '\0';
+                new_section->attributes = NULL;
+                new_section->next = NULL;
 
-                if (!current_section->attributes) {
-                    current_section->attributes = new_attr;
+                if (!header->sections) {
+                    header->sections = new_section;
                 }
                 else {
-                    Attribute* last_attr = current_section->attributes;
-                    while (last_attr->next) last_attr = last_attr->next;
-                    last_attr->next = new_attr;
+                    TBLSection* last_section = header->sections;
+                    while (last_section->next) last_section = last_section->next;
+                    last_section->next = new_section;
                 }
+                current_section = new_section;
             }
+            else {
+                fprintf(stderr, "Warning [Line %d]: TBL section missing name.\n", line_number);
+            }
+            continue;
         }
-        else {
-            fprintf(stderr, "Warning: Unknown line type '%s' encountered. Skipping.\n", tokens[0]);
+
+        // Handle ATT lines
+        if (strncmp(tokens[0], "ATT", 3) == 0) {
+            if (!current_section) {
+                fprintf(stderr, "Warning [Line %d]: ATT line encountered without an active TBL section.\n", line_number);
+                continue;
+            }
+            for (int i = 1; i < token_count; i++) {
+                if (strlen(tokens[i]) == 0) {
+                    fprintf(stderr, "Warning [Line %d]: Empty attribute name in ATT line.\n", line_number);
+                    continue;
+                }
+                // Check if there's a corresponding value
+                char* value = "";
+                if (i + 1 < token_count) {
+                    value = tokens[i + 1];
+                    i++; // Skip the value in the next token
+                }
+                add_attribute(&current_section->attributes, tokens[i], value);
+            }
+            continue;
         }
+
+        // Handle data lines or unknown lines
+        fprintf(stderr, "Warning [Line %d]: Unknown line type '%s' encountered. Skipping.\n", line_number, tokens[0]);
     }
 
     fclose(file);
@@ -103,29 +181,70 @@ TBEHeader* parse_tbe_header(const char* filename) {
 }
 
 void free_tbe_header(TBEHeader* header) {
+    if (!header) return;
+
+    // Free BGN attributes
+    Attribute* attr = header->bgn_attributes;
+    while (attr) {
+        Attribute* next_attr = attr->next;
+        free(attr);
+        attr = next_attr;
+    }
+
+    // Free EOT attributes
+    attr = header->eot_attributes;
+    while (attr) {
+        Attribute* next_attr = attr->next;
+        free(attr);
+        attr = next_attr;
+    }
+
+    // Free TBL sections and their attributes
     TBLSection* section = header->sections;
     while (section) {
-        Attribute* attr = section->attributes;
-        while (attr) {
-            Attribute* next_attr = attr->next;
-            free(attr);
-            attr = next_attr;
+        Attribute* section_attr = section->attributes;
+        while (section_attr) {
+            Attribute* next_attr = section_attr->next;
+            free(section_attr);
+            section_attr = next_attr;
         }
         TBLSection* next_section = section->next;
         free(section);
         section = next_section;
     }
+
     free(header);
 }
 
 void print_tbe_header(const TBEHeader* header) {
+    if (!header) {
+        printf("No header to display.\n");
+        return;
+    }
+
+    printf("=== Global Metadata (BGN) ===\n");
+    const Attribute* attr = header->bgn_attributes;
+    while (attr) {
+        printf("  %s: %s\n", attr->name, attr->value);
+        attr = attr->next;
+    }
+    printf("\n");
+
+    printf("=== Global Metadata (EOT) ===\n");
+    attr = header->eot_attributes;
+    while (attr) {
+        printf("  %s: %s\n", attr->name, attr->value);
+        attr = attr->next;
+    }
+    printf("\n");
+
     const TBLSection* section = header->sections;
     while (section) {
         printf("TBL Section: %s\n", section->name);
-        const Attribute* attr = section->attributes;
-        while (attr) {
-            printf("  Attribute: %s = %s\n", attr->name, attr->value);
-            attr = attr->next;
+        const Attribute* section_attr = section->attributes;
+        while (section_attr) {
+            printf("  Attribute: %s = %s\n", section_attr->name, section_attr->value);
+            section_attr = section_attr->next;
         }
         section = section->next;
         printf("\n");

--- a/c_tbe/c_conv/src/tbe_header_parser.c
+++ b/c_tbe/c_conv/src/tbe_header_parser.c
@@ -1,0 +1,133 @@
+#include "../include/tbe_header_parser.h"
+
+TBEHeader* parse_tbe_header(const char* filename) {
+    FILE* file = fopen(filename, "r");
+    if (!file) {
+        perror("Error opening TBE file");
+        return NULL;
+    }
+
+    TBEHeader* header = malloc(sizeof(TBEHeader));
+    if (!header) {
+        perror("Memory allocation failed");
+        fclose(file);
+        return NULL;
+    }
+    header->sections = NULL;
+    TBLSection* current_section = NULL;
+
+    char line[2048]; // Buffer for reading lines
+    while (fgets(line, sizeof(line), file)) {
+        line[strcspn(line, "\r\n")] = '\0'; // Remove newline characters
+        if (strlen(line) == 0) continue;   // Skip empty lines
+
+        char* tokens[50];
+        int token_count = 0;
+        char* token = strtok(line, ",");
+        while (token && token_count < 50) {
+            tokens[token_count++] = token;
+            token = strtok(NULL, ",");
+        }
+
+        if (token_count == 0) {
+            fprintf(stderr, "Warning: Empty or invalid line encountered.\n");
+            continue;
+        }
+
+        if (strncmp(tokens[0], "TBL", 3) == 0) {
+            if (token_count < 1) {
+                fprintf(stderr, "Warning: TBL section missing name.\n");
+                continue;
+            }
+
+            TBLSection* new_section = malloc(sizeof(TBLSection));
+            if (!new_section) {
+                perror("Memory allocation failed");
+                fclose(file);
+                return NULL;
+            }
+            strncpy(new_section->name, tokens[0] + 4, MAX_NAME_LEN); // Remove 'TBL ' prefix
+            new_section->attributes = NULL;
+            new_section->next = NULL;
+
+            if (!header->sections) {
+                header->sections = new_section;
+            }
+            else {
+                TBLSection* last_section = header->sections;
+                while (last_section->next) last_section = last_section->next;
+                last_section->next = new_section;
+            }
+            current_section = new_section;
+
+        }
+        else if (strncmp(tokens[0], "ATT", 3) == 0) {
+            if (!current_section) {
+                fprintf(stderr, "Warning: ATT line encountered without an active TBL section.\n");
+                continue;
+            }
+
+            for (int i = 1; i < token_count; i++) {
+                if (strlen(tokens[i]) == 0) {
+                    fprintf(stderr, "Warning: Empty attribute name in ATT line.\n");
+                    continue;
+                }
+
+                Attribute* new_attr = malloc(sizeof(Attribute));
+                if (!new_attr) {
+                    perror("Memory allocation failed");
+                    fclose(file);
+                    return NULL;
+                }
+                strncpy(new_attr->name, tokens[i], MAX_NAME_LEN);
+                new_attr->value[0] = '\0'; // Initialize value to empty
+                new_attr->next = NULL;
+
+                if (!current_section->attributes) {
+                    current_section->attributes = new_attr;
+                }
+                else {
+                    Attribute* last_attr = current_section->attributes;
+                    while (last_attr->next) last_attr = last_attr->next;
+                    last_attr->next = new_attr;
+                }
+            }
+        }
+        else {
+            fprintf(stderr, "Warning: Unknown line type '%s' encountered. Skipping.\n", tokens[0]);
+        }
+    }
+
+    fclose(file);
+    return header;
+}
+
+void free_tbe_header(TBEHeader* header) {
+    TBLSection* section = header->sections;
+    while (section) {
+        Attribute* attr = section->attributes;
+        while (attr) {
+            Attribute* next_attr = attr->next;
+            free(attr);
+            attr = next_attr;
+        }
+        TBLSection* next_section = section->next;
+        free(section);
+        section = next_section;
+    }
+    free(header);
+}
+
+void print_tbe_header(const TBEHeader* header) {
+    const TBLSection* section = header->sections;
+    while (section) {
+        printf("TBL Section: %s\n", section->name);
+        const Attribute* attr = section->attributes;
+        while (attr) {
+            printf("  Attribute: %s = %s\n", attr->name, attr->value);
+            attr = attr->next;
+        }
+        section = section->next;
+        printf("\n");
+    }
+}

--- a/c_tbe/c_conv/src/tbe_header_writer.c
+++ b/c_tbe/c_conv/src/tbe_header_writer.c
@@ -1,0 +1,47 @@
+#include "../include/tbe_header_writer.h"
+#include "../include/tbe_header_parser.h" // To access Attribute and TBEHeader
+
+int export_tbe_header(const TBEHeader* header, const char* filename) {
+    if (!header) {
+        fprintf(stderr, "Error: NULL header provided for export.\n");
+        return -1;
+    }
+
+    FILE* file = fopen(filename, "w");
+    if (!file) {
+        perror("Error opening file for writing");
+        return -1;
+    }
+
+    // Optionally, write a header line if needed
+    // fprintf(file, "TBL Global,Variable,Value\n");
+
+    // Write BGN attributes
+    const Attribute* attr = header->bgn_attributes;
+    while (attr) {
+        fprintf(file, "BGN,%s,%s\n", attr->name, attr->value);
+        attr = attr->next;
+    }
+
+    // Write TBL sections and their attributes
+    const TBLSection* section = header->sections;
+    while (section) {
+        fprintf(file, "TBL,%s\n", section->name);
+        const Attribute* section_attr = section->attributes;
+        while (section_attr) {
+            fprintf(file, "ATT,%s,%s\n", section_attr->name, section_attr->value);
+            section_attr = section_attr->next;
+        }
+        section = section->next;
+    }
+
+    // Write EOT attributes
+    attr = header->eot_attributes;
+    while (attr) {
+        fprintf(file, "EOT,%s,%s\n", attr->name, attr->value);
+        attr = attr->next;
+    }
+
+    fclose(file);
+    return 0;
+}


### PR DESCRIPTION
### NOTE: Closed because my new pull request, https://github.com/oss-slu/tbe/pull/87, fixes this issue.

## **Summary**
Fixes Issue #46. This PR enhances the TBE header parser and adds a TBE header writer, enabling the parsing, modification, and export of TBE file headers while preserving metadata and hierarchical relationships.

## **Key Features**
- **Enhanced Parsing:**
  - Parses `BGN`, `EOT`, and `TBL` sections along with `ATT` attributes.
  - Handles hierarchical relationships and stores metadata in structured C-native data types.
  - Improved error handling and suppressed unnecessary warnings.
- **New Writing Functionality:**
  - Adds functionality to export parsed metadata back to the TBE format, ensuring round-trip compatibility.
  - Preserves all metadata, including delimiters (`BGN` and `EOT`), sections (`TBL`), and attributes (`ATT`).
- **Memory Management:**
  - Ensures proper allocation and deallocation of memory for all dynamically managed data.
- **Integration:**
  - Updates the `main.c` file to demonstrate both parsing and writing functionality.
- **Updated `.gitignore` file:**
  - Excludes compiled files, build artifacts, and editor-specific files.

## **Testing**
1. Built the program with:
```
gcc -o tbe_program c_tbe/c_conv/src/main.c c_tbe/c_conv/src/tbe_header_parser.c c_tbe/c_conv/src/tbe_header_writer.c -Ic_tbe/c_conv/include
```
2. Ran with a sample file:
```
./tbe_parser
```