### PR TITLE
Added contribution guide and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,38 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Smartphone (please complete the following information):**
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+ - Browser [e.g. stock browser, safari]
+ - Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/development-task-template.md
+++ b/.github/ISSUE_TEMPLATE/development-task-template.md
@@ -1,0 +1,20 @@
+---
+name: Development task template
+about: Describe a task that needs to be completed, to make progress toward a feature.
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is this task related to a feature or a bug? Please include relevant issue numbers below.**
+This task contributes to resolving issue #
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+Fixes #issue_number
+
+**What was changed?**
+
+*Here, describe what part of the application you changed (e.g. login page, database, etc.). If possible, mention what specific components were added, removed, or modified.*
+
+**Why was it changed?**
+
+*Here, describe the issue that you are fixing with this code, and why your code fixes it.*
+
+**How was it changed?**
+
+*Here, get into detail about what files you modified, and talk about the most important lines in regards to fixing the issue.*
+
+**Screenshots that show the changes (if applicable):**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,138 @@
+# Contributing to TBE (Tabular Data with Metadata Blocks and Enrichment) project
+
+Thank you for your interest in contributing to TBE! We welcome contributions from the community to help improve and enhance the project. This document outlines the guidelines, steps, and rules for contributing to the project.
+
+## Contribution Rules
+
+To ensure a smooth and collaborative contribution process, please follow these rules:
+
+1. Be respectful and considerate towards other contributors and maintainers.
+2. Follow the project's code of conduct in all interactions and communications.
+3. Before starting work on a significant feature or change, discuss it with the maintainers through an issue or proposal to align with the project's goals and avoid duplication of efforts.
+4. Follow standard coding conventions, style guidelines, and best practices.
+5. Write clear, concise, and meaningful commit messages.
+6. Keep pull requests focused on a single logical change or feature.
+7. Provide thorough and constructive feedback when reviewing others' contributions.
+8. Be open to feedback and suggestions from maintainers and other contributors.
+9. Do not include any sensitive, confidential, or proprietary information in your contributions.
+10. By submitting a contribution, you agree to license your work under the project's chosen license.
+
+## Raising Bugs
+
+If you encounter a bug or an issue while using, please follow these steps to report it:
+
+1. Check the existing issues in the [issue tracker](https://github.com/oss-slu/tbe/issues) to see if the bug has already been reported.
+2. If the bug hasn't been reported, open a new [issue](https://github.com/oss-slu/tbe/issues/new).
+3. Provide a clear and descriptive title for the issue.
+4. Include steps to reproduce the bug, along with any relevant error messages or screenshots.
+5. Specify the environment (operating system, browser, etc.) where the bug occurs.
+
+## Proposing New Features
+
+If you have an idea for a new feature or enhancement, we encourage you to propose it to the project. Here's how you can do it:
+
+1. Check the existing issues in the [issue tracker](https://github.com/oss-slu/tbe/issues) to see if it already exists. 
+2. Open a new issue [here](https://github.com/oss-slu/tbe/issues/new).
+2. Provide a clear and descriptive title for the feature proposal.
+3. Explain the motivation and benefits of the proposed feature.
+4. Describe the proposed solution or implementation, if you have one in mind.
+5. Be open to discussions and feedback from the project maintainers and the community.
+
+## Contributing to Pull Requests
+
+To contribute code changes, please follow these steps:
+
+1. Fork the repository and create a new branch for your changes.
+2. Make your code changes in the new branch.
+3. Write clear and concise commit messages for each logical change.
+4. Make sure your code follows the project's coding conventions and style guidelines.
+5. Write unit tests to cover your code changes and ensure they pass.
+6. Update the relevant documentation, including README files and code comments, if necessary.
+7. Push your changes to your forked repository.
+8. Open a pull request against the main repository's `main` branch.
+9. Provide a clear and descriptive title for the pull request.
+10. Include a detailed description of the changes made and the problem they solve.
+11. Reference any related issues or feature requests in the pull request description.
+
+### Getting Started:
+
+- Fork this repo or
+- Clone on your local machine
+
+```terminal
+git clone https://github.com/oss-slu/tbe.git
+```
+
+- Create a new Branch
+
+```
+git checkout -b my-new-branch
+```
+- Add your changes
+```
+git add .
+```
+- Commit your changes.
+
+```
+git commit -m "Relevant message"
+```
+- Then push 
+```
+git push origin my-new-branch
+```
+
+
+- Create a new pull request from your forked repository
+
+<br>
+
+### Avoid Conflicts {Syncing your fork}
+
+An easy way to avoid conflicts is to add an 'upstream' for your git repo, as other PR's may be merged while you're working on your branch/fork.   
+
+```
+git remote add upstream https://github.com/oss-slu/tbe.git
+```
+
+You can verify that the new remote has been added by typing
+```
+git remote -v
+```
+
+To pull any new changes from your parent repo simply run
+```
+git merge upstream/main
+```
+
+This will give you any eventual conflicts and allow you to easily solve them in your repo. It's a good idea to use it frequently in between your own commits to make sure that your repo is up to date with its parent.
+
+## Documenting Changes
+
+When making changes to the codebase, it's important to keep the documentation up to date. Here are some guidelines for documenting your changes:
+
+- Update the relevant README files, documentation, or user guides to reflect the changes made.
+- Add or update code comments to explain complex or non-obvious parts of the code.
+- Include any necessary configuration or setup instructions for new features or changes.
+
+## Writing Unit Tests
+
+We encourage contributors to write unit tests for their code changes to ensure the stability and reliability of the project. When writing unit tests:
+
+- Use the project's testing framework and conventions.
+- Write tests that cover the various scenarios and edge cases related to your code changes.
+- Ensure that the tests pass successfully before submitting a pull request.
+
+## Contacting the Team
+
+If you have any questions, concerns, or need further assistance, you can join the following Open Source with SLU slack workspace and then join #project_esp channel:
+
+[Slack workspace](https://join.slack.com/t/oswslu/shared_invite/zt-24f0qhjbo-NkSfQ4LOg5wXxBdxP4vzfA)
+
+[Link to channel](https://oss-slu.slack.com/archives/C07S6MUM7DY)
+
+## Community Partners
+
+You can refer to the [Community Partners](https://oss-slu.github.io/docs/about/community) for more detailed guidance on contributing to the project.
+
+We appreciate your contributions and look forward to collaborating with you!


### PR DESCRIPTION
Fixes #82 

**What was changed?**
This pull request adds issue templates and a contribution guide

Added CONTRIBUTING.md
Added .github folder with issue templates and PR template

**Why was it changed?**
Currently, our project lacks essential documentation that is crucial for maintaining a healthy open-source community and ensuring consistent code quality. So, I added a contribution guide and issue templates to establish clear community guidelines and expectations.

How was it changed?
The following files were created:

CONTRIBUTING.md
.github/ISSUE_TEMPLATE/bug_report: Template to raise a bug
.github/ISSUE_TEMPLATE/development_task: Template for a development task to make progress towards a feature or bug
.github/ISSUE_TEMPLATE/feature_task: Template to propose a new feature
.github/pull_request_template: Template to raise a Pull Request