### PR TITLE
Add rule to .gitignore to ignore .class files

### DIFF
--- a/.gitIgnore
+++ b/.gitIgnore
@@ -1,1 +1,4 @@
 read_TBE.exe
+
+# Ignore all class files
+*.class


### PR DESCRIPTION
This PR updates the .gitignore file to include a rule for ignoring all .class files, which are generated as part of the build process and should not be tracked in the repositor