### PR TITLE
Function Script to strip_header in tbe files using R

### DIFF
--- a/r/README.md
+++ b/r/README.md
@@ -38,6 +38,18 @@ Before you start, ensure that you have the following installed on your system:
 
 ## strip_header
 
+## Overview
+The strip_header function in R extracts metadata (the header section), and returns it in a JSON format.
+
+## Prerequisites
+To use this function, Install R studio on your device.
+
+## Running the code
+Select all the code in Strip_header.r and run (ctrl+enter)
+
+## Output
+The script will run on all files in sample data and output will be displayed in json format.
+
 (Add your content here)
 
 ## unit_tests

--- a/r/src/functions/strip_header.r
+++ b/r/src/functions/strip_header.r
@@ -1,0 +1,78 @@
+# Install the jsonlite package if you haven't installed it yet
+# install.packages("jsonlite")
+library(jsonlite)
+
+strip_header <- function(filename) {
+  # Attempt to read the file
+  file_lines <- tryCatch(readLines(filename), error = function(e) NULL)
+  
+  # If file can't be read, return NULL
+  if (is.null(file_lines)) {
+    stop("Error opening file")
+  }
+  
+  metadata <- list()  # Initialize an empty list to store metadata
+  is_first_line <- TRUE  # Flag to skip the first line (header row)
+  
+  # Iterate through each line in the file
+  for (line in file_lines) {
+    # Trim newline character (R will typically handle this)
+    line <- trimws(line)
+    
+    # Skip the first line (header row)
+    if (is_first_line) {
+      is_first_line <- FALSE
+      next
+    }
+    
+    # Stop parsing if we reach the "TBL Sites" section
+    if (startsWith(line, "TBL Sites")) {
+      break
+    }
+    
+    # Split the line by comma
+    tokens <- strsplit(line, ",")[[1]]
+    
+    # Ensure there are at least 3 tokens (Key, Value, and some possible extra fields)
+    if (length(tokens) < 3) {
+      next  # Skip invalid lines
+    }
+    
+    # Extract key and value
+    key <- tokens[2]
+    value <- tokens[3]
+    
+    # Skip invalid lines (empty key or value)
+    if (nchar(key) == 0 || nchar(value) == 0) {
+      next
+    }
+    
+    # Add key-value pair to the metadata list
+    metadata[[key]] <- value
+  }
+  
+  # If no metadata was found, issue a warning
+  if (length(metadata) == 0) {
+    warning("No header detected in the file")
+  }
+  
+  # Convert the metadata list to JSON format
+  metadata_json <- toJSON(metadata, pretty = TRUE)
+  
+  return(metadata_json)
+}
+
+# Directory containing the sample files
+folder_path <- "sample_data"
+
+# Get the list of all CSV files in the directory
+csv_files <- list.files(folder_path, pattern = "\\.csv$", full.names = TRUE)
+
+# Process each CSV file and generate its metadata
+for (file in csv_files) {
+  cat("Processing file:", file, "\n")
+  metadata <- strip_header(file)
+  
+  # Print metadata for the file
+  cat(metadata, "\n\n")
+}

--- a/tbe.Rproj
+++ b/tbe.Rproj
@@ -1,0 +1,13 @@
+Version: 1.0
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX


### PR DESCRIPTION
Fixes #39

**What was changed?**

*Added script for strip_header.r to strip header from a TBE file in R, isolating it from the main data section*

**Why was it changed?**

*It is useful for users who need only the metadata information without processing the entire file*

**How was it changed?**

*Function strip_header to read a file, process it line by line, and extract the metadata (key-value pairs)*

**Screenshots that show the changes (if applicable):**
<img width="824" alt="image" src="https://github.com/user-attachments/assets/0636ef57-16fa-426e-ae70-4a112b373a45">

